### PR TITLE
Refactored representative data creation and storage  

### DIFF
--- a/src/components/CalendarImport/calendarImport.js
+++ b/src/components/CalendarImport/calendarImport.js
@@ -27,14 +27,6 @@ class CalendarImport extends Component {
       />
     ];
 
-    function getUniqueKey () {
-      if (this.state.uniquekey) {
-        return this.props.calendar.data.calendar.uniquekey;
-      } else {
-        return null;
-      }
-    }
-
     this.state = {
       putOnCalendar: 'Add these actions to your calendar!',
       calendarTitle: 'Democracy Action Agenda',
@@ -46,7 +38,7 @@ class CalendarImport extends Component {
       styles,
       uniquekey: null,
       disableImportBtn: this.disableImportBtn(),
-      calendarData: this.props.calendar
+      calendarData: props.calendar
     }
   }
 
@@ -103,7 +95,7 @@ class CalendarImport extends Component {
       }
     }
 
-    const descNoHtml = striptags(userActivity.content.rendered + 'test\n' + 'a new line\n' + 'yet another line');
+    const descNoHtml = striptags(userActivity.content.rendered);
     const descAddSpaceBetweenParagraph = descNoHtml.replace(/\./g,'. ');
 
     const title = encodeURIComponent(userActivity.title.rendered).replace(/%20/g,'+');

--- a/src/components/CalendarPickerButtons/calendarPickerButtons.js
+++ b/src/components/CalendarPickerButtons/calendarPickerButtons.js
@@ -13,13 +13,13 @@ class CalendarPickerButtons extends Component {
     super(props);
 
     this.state = {
-      uniqueKey: this.props.uniqueKey
+      uniquekey: props.uniquekey
     }
   }
 
   triggerCalendarExport (calendarType) {
-    console.log('this.state.uniqueKey', this.state.uniqueKey);
-    const calendarUrl = 'http://addevent.com/subscribe/?' + this.state.uniqueKey + '+' + calendarType;
+    console.log('this.state.uniquekey', this.state.uniquekey);
+    const calendarUrl = 'http://addevent.com/subscribe/?' + this.state.uniquekey + '+' + calendarType;
     var win = window.open(calendarUrl, '_blank');
   }
 

--- a/src/components/CalendarPickerButtons/calendarPickerButtons.js
+++ b/src/components/CalendarPickerButtons/calendarPickerButtons.js
@@ -18,7 +18,6 @@ class CalendarPickerButtons extends Component {
   }
 
   triggerCalendarExport (calendarType) {
-    console.log('this.state.uniquekey', this.state.uniquekey);
     const calendarUrl = 'http://addevent.com/subscribe/?' + this.state.uniquekey + '+' + calendarType;
     var win = window.open(calendarUrl, '_blank');
   }

--- a/src/components/UserSelectedRepList/userSelectedRepList.js
+++ b/src/components/UserSelectedRepList/userSelectedRepList.js
@@ -36,6 +36,7 @@ class UserSelectedRepList extends Component {
           <div style={styles.listItemHeader}>{rep.officialName}</div>
           <RepInfoDisplay
             repData={rep}
+            officialKey={key}
             officialsData={this.props.activities}
           />
         </li>

--- a/src/components/UserSelectedRepList/userSelectedRepList.js
+++ b/src/components/UserSelectedRepList/userSelectedRepList.js
@@ -24,10 +24,12 @@ const styles = {
 class UserSelectedRepList extends Component {
   constructor (props) {
     super(props);
+
+    console.log('props from UserSelectedRepList', props)
   }
 
   repListItems () {
-    return this.props.activities[this.props.indexOfCurrentRow].selectedReps.map((rep, key) => {
+    return this.props.activities[this.props.indexOfCurrentRow].filteredRepData.map((rep, key) => {
 
       return (
         <li
@@ -45,7 +47,9 @@ class UserSelectedRepList extends Component {
   }
 
   render () {
-    if (!this.props.activities[this.props.indexOfCurrentRow].hasOwnProperty('selectedReps')) {
+    console.log('this.props.activities[this.props.indexOfCurrentRow]', this.props.activities[this.props.indexOfCurrentRow]);
+
+    if (!this.props.activities[this.props.indexOfCurrentRow].hasOwnProperty('filteredRepData')) {
       return null;
     }
 

--- a/src/components/UserSelectedRepList/userSelectedRepList.js
+++ b/src/components/UserSelectedRepList/userSelectedRepList.js
@@ -24,8 +24,6 @@ const styles = {
 class UserSelectedRepList extends Component {
   constructor (props) {
     super(props);
-
-    console.log('props from UserSelectedRepList', props)
   }
 
   repListItems () {
@@ -35,20 +33,18 @@ class UserSelectedRepList extends Component {
         <li
           key={key}
           style={styles.listItem}>
-          <div style={styles.listItemHeader}>{rep.officialName}</div>
-          <RepInfoDisplay
-            repData={rep}
-            officialKey={key}
-            officialsData={this.props.activities}
-          />
+          <div>{rep.officialName}</div>
+          <div>{rep.officialTitle}</div>
+          {renderOfficialPhoneNumbers(rep.officialPhones)}
+          Party: <strong>{rep.officialParty}</strong>
+          {renderUrls(rep.officialUrls)}
+          {renderChannels(rep.officialChannels)}
         </li>
       )
     });
   }
 
   render () {
-    console.log('this.props.activities[this.props.indexOfCurrentRow]', this.props.activities[this.props.indexOfCurrentRow]);
-
     if (!this.props.activities[this.props.indexOfCurrentRow].hasOwnProperty('filteredRepData')) {
       return null;
     }

--- a/src/containers/FindRep/findRepresentative.js
+++ b/src/containers/FindRep/findRepresentative.js
@@ -6,7 +6,7 @@ import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowCol
 import { browserHistory } from 'react-router';
 import { connect } from 'react-redux';
 import _ from 'lodash';
-import { RepInfoDisplay, renderChannels, renderUrls, renderOfficialAddresses, renderOfficialTitle, renderOfficialPhoneNumbers, colors } from './renderRepData';
+import { RepInfoDisplay, getChannels, renderChannels, getUrls, renderUrls, getOfficialAddresses, renderOfficialAddresses, renderOfficialTitle, getOfficialPhoneNumbers, renderOfficialPhoneNumbers, colors } from './renderRepData';
 
 const style = {
   officialName: {
@@ -56,7 +56,6 @@ let tempSelectedOfficials = [];
 class FindRep extends Component {
   constructor(props) {
     super(props);
-
 
     this.state = {
       cardTitleText: 'Find your local representative by entering your home address',
@@ -199,6 +198,7 @@ class FindRep extends Component {
         });
       }).
       catch((err) => {
+        console.log('err', err);
         this.setState({
           representativeData: 'BAD',
           isLoadingRepData: false
@@ -208,15 +208,26 @@ class FindRep extends Component {
   }
 
   submitSelectedRepList() {
-    let selectedRepList = [];
+    let selectedRepList = _.uniqBy(this.state.selectedOfficials, 'tempIdx');
+
+    let filteredRepData = selectedRepList.map((val, key) => {
+      return {
+        officialName: val.name,
+        officialTitle: renderOfficialTitle(this.state.representativeData, val.tempIdx),
+        officialAddresses: getOfficialAddresses(val.address),
+        officialPhones: getOfficialPhoneNumbers(val.phones),
+        officialParty: val.party,
+        officialUrls: val.urls,
+        officialChannels: getChannels(val.channels)
+      }
+    });
 
     const tempActivityData = this.props.tempActivityData;
 
     // here we update the selected activity data with this new rep list
     const activityDataWithReps = _.merge({}, tempActivityData, {
-      // need to dedup here because each click of the checkbox to add
-      // a rep seems to be firing multiple times, adding the rep multiple times
-      selectedReps: _.uniqBy(this.state.selectedOfficials, 'tempIdx')
+      selectedRepList,
+      filteredRepData
     });
 
     this.props.addUserActivity(activityDataWithReps);

--- a/src/containers/FindRep/findRepresentative.js
+++ b/src/containers/FindRep/findRepresentative.js
@@ -198,7 +198,6 @@ class FindRep extends Component {
         });
       }).
       catch((err) => {
-        console.log('err', err);
         this.setState({
           representativeData: 'BAD',
           isLoadingRepData: false

--- a/src/containers/FindRep/findRepresentative.js
+++ b/src/containers/FindRep/findRepresentative.js
@@ -110,6 +110,7 @@ class FindRep extends Component {
             <TableRowColumn style={style.tableRowColumn}>
               <RepInfoDisplay
                 repData={data}
+                officialKey={key}
                 officialsData={officialsData}
                 headerStyle={style.officialName}
               />

--- a/src/containers/FindRep/renderRepData.js
+++ b/src/containers/FindRep/renderRepData.js
@@ -173,8 +173,6 @@ export class RepInfoDisplay extends Component {
   }
 
   render () {
-    console.log('this.props.officialKey', this.props.officialKey);
-
     return (
       <div>
         <h3 style={style.officialName}>{this.props.repData.name}</h3>

--- a/src/containers/FindRep/renderRepData.js
+++ b/src/containers/FindRep/renderRepData.js
@@ -27,11 +27,23 @@ const style = {
   },
 }
 
+export function getChannels (channels) {
+  let channelUrlList = [];
+
+  if (channels) {
+    channelUrlList = channels.map((channel, key) => {
+      return channel
+    });
+  }
+
+  return channelUrlList;
+}
+
 export function renderChannels (channels) {
   let channelUrl;
 
   if (channels) {
-    return channels.map((channel, key) => {
+    return getChannels(channels).map((channel, key) => {
 
       switch(channel.type) {
         case 'GooglePlus':
@@ -63,9 +75,21 @@ export function renderChannels (channels) {
   }
 }
 
+export function getUrls(urls) {
+  if (urls) {
+    let urlList = [];
+
+    urlList = urls.map((url, key) => {
+      return url;
+    });
+
+    return urlList;
+  }
+}
+
 export function renderUrls(urls) {
   if (urls) {
-    return urls.map((url, key) => {
+    return getUrls(urls).map((url, key) => {
       return (
         <div key={key}>
           <a
@@ -81,9 +105,21 @@ export function renderUrls(urls) {
   }
 }
 
+export function getOfficialAddresses(addressInfo) {
+  if (addressInfo) {
+    let repOfficeAddresses = [];
+
+    repOfficeAddresses = addressInfo.map((address, key) => {
+      return address;
+    });
+
+    return repOfficeAddresses;
+  }
+}
+
 export function renderOfficialAddresses(addressInfo) {
   if (addressInfo) {
-    return addressInfo.map((address, key) => {
+    return getOfficialAddresses(addressInfo).map((address, key) => {
       return (
         <div className="official-address" key={key}>
           {address.line1},<br />
@@ -95,7 +131,7 @@ export function renderOfficialAddresses(addressInfo) {
 }
 
 export function renderOfficialTitle(allData, officialKey) {
-  var officeName;
+  let officeName;
 
   _.each(allData.offices, (office, officeKey) => {
     return _.each(office.officialIndices, (indice, indiceKey) => {
@@ -106,21 +142,29 @@ export function renderOfficialTitle(allData, officialKey) {
     });
   })
 
-  return (
-    <span style={style.officeName}>{officeName}</span>
-  )
+  return officeName;
+}
+
+export function getOfficialPhoneNumbers (phoneNumbers) {
+  let phoneNumList = [];
+
+  if (phoneNumbers) {
+    phoneNumList = phoneNumbers.map((number, key) => {
+      return number;
+    });
+  }
+
+  return phoneNumList;
 }
 
 export function renderOfficialPhoneNumbers (phoneNumbers) {
-  if (phoneNumbers) {
-    return phoneNumbers.map((number, key) => {
-      return (
-        <div key={key} style={style.officialPhones}>
-          {number}
-        </div>
-      )
-    });
-  }
+    return getOfficialPhoneNumbers(phoneNumbers).map((number, key) => {
+    return (
+      <div key={key} style={style.officialPhones}>
+        {number}
+      </div>
+    )
+  });
 }
 
 export class RepInfoDisplay extends Component {
@@ -134,7 +178,7 @@ export class RepInfoDisplay extends Component {
     return (
       <div>
         <h3 style={style.officialName}>{this.props.repData.name}</h3>
-        {renderOfficialTitle(this.props.officialsData, this.props.officialKey)}
+        <span style={style.officeName}>{renderOfficialTitle(this.props.officialsData, this.props.officialKey)}</span>
         {renderOfficialAddresses(this.props.repData.address)}
         {renderOfficialPhoneNumbers(this.props.repData.phones)}
         Party: <strong>{this.props.repData.party}</strong>

--- a/src/containers/FindRep/renderRepData.js
+++ b/src/containers/FindRep/renderRepData.js
@@ -129,12 +129,12 @@ export class RepInfoDisplay extends Component {
   }
 
   render () {
-
+    console.log('this.props.officialKey', this.props.officialKey);
 
     return (
       <div>
         <h3 style={style.officialName}>{this.props.repData.name}</h3>
-        {renderOfficialTitle(this.props.officialsData, this.props.key)}
+        {renderOfficialTitle(this.props.officialsData, this.props.officialKey)}
         {renderOfficialAddresses(this.props.repData.address)}
         {renderOfficialPhoneNumbers(this.props.repData.phones)}
         Party: <strong>{this.props.repData.party}</strong>

--- a/src/reducers/reducer_userActivities.js
+++ b/src/reducers/reducer_userActivities.js
@@ -6,7 +6,6 @@ let tempActivityList
 
 const INITIAL_STATE = {
   all: [],
-  selectedReps: [],
   tempActivityData: {}
 };
 


### PR DESCRIPTION
This will make it easier to pass this data around, as I created a new property on the userActivities object that gives you all of the data already processed so that all you need to do is render the markup. This was mainly done for the purpose of displaying the representative title, which, due to the poor design of Google Civic's API, requires a lot of fancy footwork to display properly, so it was deemed better to just get the title once and save it to the global state as a string. 